### PR TITLE
Edits for consistency and developer QOL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ venv/
 env/
 .venv/
 .env/
+my_env/
 
 # Data files
 *.csv

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Feel free to simply copy and paste the code snippets in the notebooks. If you pr
    source my_env/bin/activate  # On Windows, use `my_env\Scripts\activate`
    ```
 
+3. Once you have an API key, we recommend that you store it as an environment variable in a `.env` file like so:
+
+   ```
+   WRITER_API_KEY="{Your Writer API key goes here}"
+   ```
+
 ## Running the cookbooks
 
 1. Ensure your virtual environment is activated.

--- a/completion/chat_completion.ipynb
+++ b/completion/chat_completion.ipynb
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "9980e957-6193-4086-8ecd-ce921ca3eaef",
    "metadata": {},
    "outputs": [],
@@ -125,7 +125,7 @@
     "\n",
     "Now that you have a Writer client instance, it’s time to start building chat completion apps! \n",
     "\n",
-    "The `chat` property of a Writer client instance contains methods and properties related to chat completion. In all the examples in this cookbook, you’ll build chat completion apps by using the `chat` property’s `chat()` method, which makes requests for chat completions from Palmyra."
+    "The `chat` property of a Writer client instance contains methods and properties related to chat completion. In all the examples in this cookbook, you’ll build chat completion apps by using the `chat` property’s `chat()` method, which makes requests for chat completions from Palmyra, Writer's custom model."
    ]
   },
   {
@@ -229,7 +229,7 @@
     "            <ul>\n",
     "                <li>The default value is 1.</li>\n",
     "                <li>At temperatures <em>below</em> 1, the responses are more deterministic and predictable, with Palmyra tending to choose the highest probability tokens based on previously-generated ones. The generated output is predictable and repetitive, and produces more \"safe\" or \"obvious\" answers.</li>\n",
-    "                <li>At temperatures <em>above</em> 1, the responses are more random and “imaginative,”  with Palmyra giving less probable tokens a better chance of being chosen. The generated output is predictable and repetitive, and produces more \"safe\" or \"obvious\" answers. The generated output is less predictable, and produces more “creative” answers. The results become increasingly nonsensical at temperatures of about 1.4 and higher, especially for longer completions.</li>\n",
+    "                <li>At temperatures <em>above</em> 1, the responses are more random and “imaginative,”  with Palmyra giving less probable tokens a better chance of being chosen. The generated output is less predictable, and produces more “creative” answers. The results become increasingly nonsensical at temperatures of about 1.4 and higher, especially for longer completions.</li>\n",
     "            </ul>\n",
     "        </td>\n",
     "    </tr>\n",

--- a/completion/text_completion.ipynb
+++ b/completion/text_completion.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "The cell below performs the initialization required for this notebook including the creation of an instance of the `Writer` object to interact with the LLM.\n",
     "\n",
-    "To create a Palmyra client object, you need an API key. [You can sign up for one for free](https://app.writer.com/aistudio/signup). \n",
+    "To create a Writer client object, you need an API key. [You can sign up for one for free](https://app.writer.com/aistudio/signup). \n",
     "\n",
     "Once you have an API key, we recommend that you store it as an environment variable in a `.env` file like so:\n",
     "\n",
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "6caf3075-f997-4602-97a7-676c08350dd8",
    "metadata": {},
    "outputs": [],
@@ -113,7 +113,7 @@
     "\n",
     "Now that you have a Writer client instance, it’s time to start building text completion apps! \n",
     "\n",
-    "The `completions` property of a Writer client instance contains methods and properties related to text completion. In all the examples in this cookbook, you’ll build text completion apps by using the `completions` property’s `create()` method, which makes requests for text completions from Palmyra."
+    "The `completions` property of a Writer client instance contains methods and properties related to text completion. In all the examples in this cookbook, you’ll build text completion apps by using the `completions` property’s `create()` method, which makes requests for text completions from Palmyra, Writer's custom model."
    ]
   },
   {
@@ -219,7 +219,7 @@
     "            <ul>\n",
     "                <li>The default value is 1.</li>\n",
     "                <li>At temperatures <em>below</em> 1, the responses are more deterministic and predictable, with Palmyra tending to choose the highest probability tokens based on previously-generated ones. The generated output is predictable and repetitive, and produces more \"safe\" or \"obvious\" answers.</li>\n",
-    "                <li>At temperatures <em>above</em> 1, the responses are more random and “imaginative,”  with Palmyra giving less probable tokens a better chance of being chosen. The generated output is predictable and repetitive, and produces more \"safe\" or \"obvious\" answers. The generated output is less predictable, and produces more “creative” answers. The results become increasingly nonsensical at temperatures of about 1.4 and higher, especially for longer completions.</li>\n",
+    "                <li>At temperatures <em>above</em> 1, the responses are more random and “imaginative,”  with Palmyra giving less probable tokens a better chance of being chosen. The generated output is less predictable, and produces more “creative” answers. The results become increasingly nonsensical at temperatures of about 1.4 and higher, especially for longer completions.</li>\n",
     "            </ul>\n",
     "        </td>\n",
     "    </tr>\n",

--- a/knowledge_graph/knowledge_graph.ipynb
+++ b/knowledge_graph/knowledge_graph.ipynb
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "856a23a8-9aa6-4f38-b9c7-4b48afe6929b",
    "metadata": {},
    "outputs": [],
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "ebd32e2a-0ab8-4a45-8401-abc846373deb",
    "metadata": {},
    "outputs": [],
@@ -430,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "25ad1fb4-2c95-459f-b710-1fe30813108c",
    "metadata": {},
    "outputs": [],
@@ -478,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "0823eb8a-045f-486a-82a2-9147911f84bf",
    "metadata": {},
    "outputs": [],
@@ -615,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "9faa539b",
    "metadata": {},
    "outputs": [],

--- a/models/model_retrieval.ipynb
+++ b/models/model_retrieval.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "The cell below performs the initialization required for this notebook including the creation of an instance of the `Writer` object to interact with the LLM.\n",
     "\n",
-    "To create a Palmyra client object, you need an API key. [You can sign up for one for free](https://app.writer.com/aistudio/signup). \n",
+    "To create a Writer client object, you need an API key. [You can sign up for one for free](https://app.writer.com/aistudio/signup). \n",
     "\n",
     "Once you have an API key, we recommend that you store it as an environment variable in a `.env` file like so:\n",
     "\n",
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "0497d092-b7e1-4ccb-86d5-1643f3d8404c",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Some documentation updates for the cookbooks:

1. User "Writer API" vs. "Palmyra API" consistently.
2. Define "Palmyra" at first use.
3. Hoist .env file recommendation as part of getting the API key.
4. Ignore `my_env` generated per the instructions.
